### PR TITLE
Fix bug with duplicate entries

### DIFF
--- a/app/env.js
+++ b/app/env.js
@@ -9,3 +9,6 @@ exports.NODE_ENV = process.env.NODE_ENV;
 // will looks for issues closed this many seconds after the tag,  this may happen if the issue is merged via a MR and automatially closed
 // example -e GITLAB_ISSUE_SECOND_DELAY=60 will catch issues closed up to 60 seconds after the tag is created.
 exports.ISSUE_CLOSED_SECONDS = process.env.ISSUE_CLOSED_SECONDS || "0" 
+
+// this variable does similar thing as $ISSUE_CLOSED_SECONDS but works with startDate instead of endDate
+exports.START_DATE_SHIFT = process.env.START_DATE_SHIFT || "0" 

--- a/app/lib/generator.js
+++ b/app/lib/generator.js
@@ -13,8 +13,16 @@ exports.generate = async () => {
   const [latestTag, secondLatestTag] = tags;
 
   if (!_.get(latestTag, "commit.committed_date") || !_.get(secondLatestTag, "commit.committed_date")) throw new Error(`Cannot find latest and second latest tag. Abort the program!`);
-  const startDate = _.get(secondLatestTag, "commit.committed_date");
+  let startDate = _.get(secondLatestTag, "commit.committed_date");
   let endDate = _.get(latestTag, "commit.committed_date");
+
+  // allow start date to be adjusted
+  if (Env.START_DATE_SHIFT > 0) {
+    Logger.debug(`startDate:        ${startDate}`);
+    Logger.debug(`Adding Seconds: ${Env.START_DATE_SHIFT}`);
+    startDate = Moment.tz(startDate, Env.TZ).add(Env.START_DATE_SHIFT, "seconds").utc().format();
+    Logger.debug(`New startDate:   ${startDate}`);
+  }
 
   // allow the end date to be adjusted by a few seconds to catch issues that are automatially closed by
   // a MR and are time stamped a few seconds later.


### PR DESCRIPTION
By introducing a variable I've managed to fix bug that causes a single merged merge request to appear in two sequential releases.